### PR TITLE
Revert main to bdb637c3

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3667,9 +3667,9 @@ dependencies = [
 
 [[package]]
 name = "stack_epic_wallet_api"
-version = "3.3.5"
+version = "3.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14261f4c5801b3f7509d4ed850a64bd701d5f1eb121b39d6457987b13fd5d2f"
+checksum = "da20962097c70682fddf8580117f4595cbd5be35101469ec9ff3701bde006041"
 dependencies = [
  "base64 0.9.3",
  "chrono",
@@ -3706,9 +3706,9 @@ dependencies = [
 
 [[package]]
 name = "stack_epic_wallet_controller"
-version = "3.3.5"
+version = "3.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f0cc6e477e150a67481e905d344a9a540c834d93771f0e7abfd636fc0041ae2"
+checksum = "fbd2218e8b50e1bbd669cf4be38da293f32a05a48b0355436fe6b06043ec0df7"
 dependencies = [
  "chrono",
  "easy-jsonrpc-mw",
@@ -3740,9 +3740,9 @@ dependencies = [
 
 [[package]]
 name = "stack_epic_wallet_impls"
-version = "3.3.5"
+version = "3.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0691f2f0377f4626cf90941fd827ef95dc0af2e55fa3698e899a9ff30dbc9258"
+checksum = "68c9137ee6d59bd95678a466b04ce3d6a2946f5735adc592390bd8d06a80bae6"
 dependencies = [
  "bitvec",
  "blake2-rfc",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -45,15 +45,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,17 +388,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
- "iana-time-zone",
- "js-sys",
+ "libc",
  "num-integer",
  "num-traits 0.2.15",
  "serde",
  "time",
- "wasm-bindgen",
  "winapi 0.3.9",
 ]
 
@@ -454,16 +443,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
 ]
 
 [[package]]
@@ -716,50 +695,6 @@ dependencies = [
  "digest 0.8.1",
  "rand_core 0.3.1",
  "subtle",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a140f260e6f3f79013b8bfc65e7ce630c9ab4388c6a89c71e07226f49487b72"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da6383f459341ea689374bf0a42979739dc421874f112ff26f829b8040b8e613"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "scratch",
- "syn 1.0.95",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90201c1a650e95ccff1c8c0bb5a343213bdd317c6e600a93075bca2eff54ec97"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
-dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
 ]
 
 [[package]]
@@ -1566,30 +1501,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c17cc76786e99f8d2f055c11159e7f0091c42474dcc3189fbab96072e873e6d"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
-dependencies = [
- "cxx",
- "cxx-build",
-]
-
-[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1793,15 +1704,6 @@ checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
  "cc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -3159,12 +3061,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
-
-[[package]]
 name = "sct"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3667,9 +3563,9 @@ dependencies = [
 
 [[package]]
 name = "stack_epic_wallet_api"
-version = "3.3.4"
+version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da20962097c70682fddf8580117f4595cbd5be35101469ec9ff3701bde006041"
+checksum = "696ce119567ec587c7b4f6b6f0db978d75a0aba4554e1cce92fcf4133a8d206e"
 dependencies = [
  "base64 0.9.3",
  "chrono",
@@ -3692,9 +3588,9 @@ dependencies = [
 
 [[package]]
 name = "stack_epic_wallet_config"
-version = "3.3.4"
+version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ba92d69856c8de9617bf408498dd5202bff7e9ab2f4a80a357e07036ddc0e"
+checksum = "b013fbc610783061a0cabfe207fdb3636873afcceb363802046cd37694ee29c7"
 dependencies = [
  "dirs 1.0.5",
  "rand 0.5.6",
@@ -3706,9 +3602,9 @@ dependencies = [
 
 [[package]]
 name = "stack_epic_wallet_controller"
-version = "3.3.4"
+version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd2218e8b50e1bbd669cf4be38da293f32a05a48b0355436fe6b06043ec0df7"
+checksum = "385113c61b3741fe628560d51d7f68f8c65f3dddb4f079902e9f529148767b7d"
 dependencies = [
  "chrono",
  "easy-jsonrpc-mw",
@@ -3740,9 +3636,9 @@ dependencies = [
 
 [[package]]
 name = "stack_epic_wallet_impls"
-version = "3.3.4"
+version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c9137ee6d59bd95678a466b04ce3d6a2946f5735adc592390bd8d06a80bae6"
+checksum = "06b1abf9d446bb4611cbbf3be806dfcdd37ed1dd1b693f8d21bd0110952089c6"
 dependencies = [
  "bitvec",
  "blake2-rfc",
@@ -3784,9 +3680,9 @@ dependencies = [
 
 [[package]]
 name = "stack_epic_wallet_libwallet"
-version = "3.3.4"
+version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eae02504332c65432b9abeaa3f8f083d66c3b5a9db7920219b358439eefe2fa"
+checksum = "ca0a34fb7c3e15fb73141832725c4af6e6fcb3c62b4c75a1f359dae510ed6866"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -3811,15 +3707,14 @@ dependencies = [
  "stack_epic_wallet_util",
  "strum",
  "strum_macros",
- "tungstenite 0.18.0",
  "uuid 0.7.4",
 ]
 
 [[package]]
 name = "stack_epic_wallet_util"
-version = "3.3.4"
+version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb1219ee3dffd58306b2745bda331ad63ce6951854d9a267e587e4f553b5d85"
+checksum = "651302e41e93dd449a027b5af38d385f15b254311a99a60ab1bdf3674d7472c8"
 dependencies = [
  "dirs 1.0.5",
  "rand 0.5.6",
@@ -5217,47 +5112,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5266,22 +5131,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5290,40 +5143,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winreg"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -31,12 +31,12 @@ stack_epic_keychain = "3.3.2"
 stack_epic_util = "3.3.2"
 stack_epic_core = "3.3.2"
 
-stack_epic_wallet_api = "3.3.5"
-stack_epic_wallet_impls = "3.3.5"
-stack_epic_wallet_libwallet = "3.3.4"
-stack_epic_wallet_config = "3.3.4"
-stack_epic_wallet_util = "3.3.4"
-stack_epic_wallet_controller = "3.3.5"
+stack_epic_wallet_api = "3.3.2"
+stack_epic_wallet_impls = "3.3.2"
+stack_epic_wallet_libwallet = "3.3.2"
+stack_epic_wallet_config = "3.3.2"
+stack_epic_wallet_util = "3.3.2"
+stack_epic_wallet_controller = "3.3.2"
 
 # Epic box for posting slates and getting epic addresses
 stack_test_epicboxlib = "1.0.3"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,18 +25,18 @@ rand = "0.6"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 rustc-serialize = "0.3.24"
 android_logger = "0.11.0"
-chrono = "0.4.19"
+chrono = "0.4.24"
 
 stack_epic_keychain = "3.3.2"
 stack_epic_util = "3.3.2"
 stack_epic_core = "3.3.2"
 
-stack_epic_wallet_api = "3.3.2"
-stack_epic_wallet_impls = "3.3.2"
-stack_epic_wallet_libwallet = "3.3.2"
-stack_epic_wallet_config = "3.3.2"
-stack_epic_wallet_util = "3.3.2"
-stack_epic_wallet_controller = "3.3.2"
+stack_epic_wallet_api = "3.3.4"
+stack_epic_wallet_impls = "3.3.4"
+stack_epic_wallet_libwallet = "3.3.4"
+stack_epic_wallet_config = "3.3.4"
+stack_epic_wallet_util = "3.3.4"
+stack_epic_wallet_controller = "3.3.4"
 
 # Epic box for posting slates and getting epic addresses
 stack_test_epicboxlib = "1.0.3"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,18 +25,18 @@ rand = "0.6"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 rustc-serialize = "0.3.24"
 android_logger = "0.11.0"
-chrono = "0.4.24"
+chrono = "0.4.19"
 
 stack_epic_keychain = "3.3.2"
 stack_epic_util = "3.3.2"
 stack_epic_core = "3.3.2"
 
-stack_epic_wallet_api = "3.3.4"
-stack_epic_wallet_impls = "3.3.4"
-stack_epic_wallet_libwallet = "3.3.4"
-stack_epic_wallet_config = "3.3.4"
-stack_epic_wallet_util = "3.3.4"
-stack_epic_wallet_controller = "3.3.4"
+stack_epic_wallet_api = "3.3.2"
+stack_epic_wallet_impls = "3.3.2"
+stack_epic_wallet_libwallet = "3.3.2"
+stack_epic_wallet_config = "3.3.2"
+stack_epic_wallet_util = "3.3.2"
+stack_epic_wallet_controller = "3.3.2"
 
 # Epic box for posting slates and getting epic addresses
 stack_test_epicboxlib = "1.0.3"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -96,7 +96,7 @@ fn init_logger() {
 }
 
 impl Config {
-    pub fn from_str(json: &str) -> Result<Self, serde_json::error::Error> {
+    fn from_str(json: &str) -> Result<Self, serde_json::error::Error> {
         let result = match  serde_json::from_str::<Config>(json) {
             Ok(config) => {
                 config
@@ -558,6 +558,10 @@ pub unsafe extern "C" fn rust_create_tx(
         wallet_data: tuple_wallet_data.clone(),
         epicbox_config: epicbox_config.parse().unwrap()
     };
+
+    let handle = listener_spawn(&listen);
+    listener_cancel(handle);
+    debug!("LISTENER CANCELLED IS {}", listener_cancelled(handle));
 
     let wlt = tuple_wallet_data.0;
     let sek_key = tuple_wallet_data.1;


### PR DESCRIPTION
This returns #main to the tested-working state of bdb637c3

 - [ ] Retest these reverted commits/merges before reverting main and only revert what's needed