### PR TITLE
Update android ndk so epiccash builds with rustc 1.72.1 (Still need ios and macOS test)

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.8.0'
     repositories {
         google()
         mavenCentral()
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/scripts/android/config.sh
+++ b/scripts/android/config.sh
@@ -3,6 +3,6 @@
 export API=21
 export WORKDIR="$(pwd)/"build
 #r21e also works and was the preferred before
-export ANDROID_NDK_ZIP=${WORKDIR}/android-ndk-r20b.zip
-export ANDROID_NDK_ROOT=${WORKDIR}/android-ndk-r20b
+export ANDROID_NDK_ZIP=${WORKDIR}/android-ndk-r26-linux.zip
+export ANDROID_NDK_ROOT=${WORKDIR}/android-ndk-r26
 export ANDROID_NDK_HOME=$ANDROID_NDK_ROOT

--- a/scripts/android/install_ndk.sh
+++ b/scripts/android/install_ndk.sh
@@ -2,10 +2,10 @@
 
 mkdir build
 . ./config.sh
-ANDROID_NDK_SHA256="8381c440fe61fcbb01e209211ac01b519cd6adf51ab1c2281d5daad6ca4c8c8c"
+ANDROID_NDK_SHA1="d3bef08e0e43acd9e7815538df31818692d548bb"
 
 if [ ! -e "$ANDROID_NDK_ZIP" ]; then
-  curl https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip -o ${ANDROID_NDK_ZIP}
+  curl https://dl.google.com/android/repository/android-ndk-r26-linux.zip -o ${ANDROID_NDK_ZIP}
 fi
-echo $ANDROID_NDK_SHA256 $ANDROID_NDK_ZIP | sha256sum -c || exit 1
+echo $ANDROID_NDK_SHA1 $ANDROID_NDK_ZIP | sha1sum -c || exit 1
 unzip $ANDROID_NDK_ZIP -d $WORKDIR


### PR DESCRIPTION
Older android ndks don't work with the latest rust version, upgraded  ndk version to latest for android build