### PR TITLE
Add ConfirmedCoinbase to TransactionType enum

### DIFF
--- a/lib/models/transaction.dart
+++ b/lib/models/transaction.dart
@@ -120,4 +120,6 @@ enum TransactionType {
   TxReceivedCancelled,
   TxSent,
   TxSentCancelled,
+  ConfirmedCoinbase,
+  // UnconfirmedCoinbase, // This probably also exists.
 }


### PR DESCRIPTION
Resolves issue on restore where ConfirmedCoinbase type transactions break tx parsing