### PR TITLE
Error handling

### DIFF
--- a/lib/lib.dart
+++ b/lib/lib.dart
@@ -1,11 +1,11 @@
 import 'dart:convert';
+import 'dart:ffi';
 
 import 'package:decimal/decimal.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_libepiccash/epic_cash.dart' as lib_epiccash;
 import 'package:flutter_libepiccash/models/transaction.dart';
 import 'package:mutex/mutex.dart';
-import 'dart:ffi';
 
 class BadEpicHttpAddressException implements Exception {
   final String? message;
@@ -67,13 +67,13 @@ abstract class LibEpiccash {
 
   // Private function wrapper for compute
   static Future<String> _initializeWalletWrapper(
-      ({
+    ({
       String config,
       String mnemonic,
       String password,
       String name,
-      }) data,
-      ) async {
+    }) data,
+  ) async {
     final String initWalletStr = lib_epiccash.initWallet(
       data.config,
       data.mnemonic,
@@ -99,10 +99,10 @@ abstract class LibEpiccash {
         return await compute(
           _initializeWalletWrapper,
           (
-          config: config,
-          mnemonic: mnemonic,
-          password: password,
-          name: name,
+            config: config,
+            mnemonic: mnemonic,
+            password: password,
+            name: name,
           ),
         );
       } catch (e) {
@@ -115,8 +115,8 @@ abstract class LibEpiccash {
   /// Private function wrapper for wallet balances
   ///
   static Future<String> _walletBalancesWrapper(
-      ({String wallet, int refreshFromNode, int minimumConfirmations}) data,
-      ) async {
+    ({String wallet, int refreshFromNode, int minimumConfirmations}) data,
+  ) async {
     return lib_epiccash.getWalletInfo(
         data.wallet, data.refreshFromNode, data.minimumConfirmations);
   }
@@ -125,22 +125,22 @@ abstract class LibEpiccash {
   /// Get balance information for the currently open wallet
   ///
   static Future<
-      ({
-      double awaitingFinalization,
-      double pending,
-      double spendable,
-      double total
-      })>
-  getWalletBalances(
-      {required String wallet,
-        required int refreshFromNode,
-        required int minimumConfirmations}) async {
+          ({
+            double awaitingFinalization,
+            double pending,
+            double spendable,
+            double total
+          })>
+      getWalletBalances(
+          {required String wallet,
+          required int refreshFromNode,
+          required int minimumConfirmations}) async {
     return await m.protect(() async {
       try {
         String balances = await compute(_walletBalancesWrapper, (
-        wallet: wallet,
-        refreshFromNode: refreshFromNode,
-        minimumConfirmations: minimumConfirmations,
+          wallet: wallet,
+          refreshFromNode: refreshFromNode,
+          minimumConfirmations: minimumConfirmations,
         ));
 
         //If balances is valid json return, else return error
@@ -150,15 +150,15 @@ abstract class LibEpiccash {
         var jsonBalances = json.decode(balances);
         //Return balances as record
         ({
-        double spendable,
-        double pending,
-        double total,
-        double awaitingFinalization
+          double spendable,
+          double pending,
+          double total,
+          double awaitingFinalization
         }) balancesRecord = (
-        spendable: jsonBalances['amount_currently_spendable'],
-        pending: jsonBalances['amount_awaiting_finalization'],
-        total: jsonBalances['total'],
-        awaitingFinalization: jsonBalances['amount_awaiting_finalization'],
+          spendable: jsonBalances['amount_currently_spendable'],
+          pending: jsonBalances['amount_awaiting_finalization'],
+          total: jsonBalances['total'],
+          awaitingFinalization: jsonBalances['amount_awaiting_finalization'],
         );
         return balancesRecord;
       } catch (e) {
@@ -171,8 +171,8 @@ abstract class LibEpiccash {
   /// Private function wrapper for scanning output function
   ///
   static Future<String> _scanOutputsWrapper(
-      ({String wallet, int startHeight, int numberOfBlocks}) data,
-      ) async {
+    ({String wallet, int startHeight, int numberOfBlocks}) data,
+  ) async {
     return lib_epiccash.scanOutPuts(
       data.wallet,
       data.startHeight,
@@ -221,8 +221,8 @@ abstract class LibEpiccash {
       String epicboxConfig,
       int minimumConfirmations,
       String note,
-      }) data,
-      ) async {
+    }) data,
+  ) async {
     return lib_epiccash.createTransaction(
         data.wallet,
         data.amount,
@@ -248,13 +248,13 @@ abstract class LibEpiccash {
     return await m.protect(() async {
       try {
         String result = await compute(_createTransactionWrapper, (
-        wallet: wallet,
-        amount: amount,
-        address: address,
-        secretKeyIndex: secretKeyIndex,
-        epicboxConfig: epicboxConfig,
-        minimumConfirmations: minimumConfirmations,
-        note: note,
+          wallet: wallet,
+          amount: amount,
+          address: address,
+          secretKeyIndex: secretKeyIndex,
+          epicboxConfig: epicboxConfig,
+          minimumConfirmations: minimumConfirmations,
+          note: note,
         ));
 
         if (result.toUpperCase().contains("ERROR")) {
@@ -268,11 +268,12 @@ abstract class LibEpiccash {
         final part2 = jsonDecode(slate[1] as String);
 
         List<dynamic>? outputs = part2['tx']?['body']?['outputs'] as List;
-        String? commitId = (outputs.isEmpty) ? '' : outputs[0]['commit'] as String;
+        String? commitId =
+            (outputs.isEmpty) ? '' : outputs[0]['commit'] as String;
 
         ({String slateId, String commitId}) data = (
-        slateId: part1[0]['tx_slate_id'],
-        commitId: commitId,
+          slateId: part1[0]['tx_slate_id'],
+          commitId: commitId,
         );
 
         return data;
@@ -286,11 +287,11 @@ abstract class LibEpiccash {
   /// Private function wrapper for get transactions
   ///
   static Future<String> _getTransactionsWrapper(
-      ({
+    ({
       String wallet,
       int refreshFromNode,
-      }) data,
-      ) async {
+    }) data,
+  ) async {
     return lib_epiccash.getTransactions(
       data.wallet,
       data.refreshFromNode,
@@ -307,8 +308,8 @@ abstract class LibEpiccash {
     return await m.protect(() async {
       try {
         var result = await compute(_getTransactionsWrapper, (
-        wallet: wallet,
-        refreshFromNode: refreshFromNode,
+          wallet: wallet,
+          refreshFromNode: refreshFromNode,
         ));
 
         if (result.toUpperCase().contains("ERROR")) {
@@ -335,11 +336,11 @@ abstract class LibEpiccash {
   /// Private function for cancel transaction function
   ///
   static Future<String> _cancelTransactionWrapper(
-      ({
+    ({
       String wallet,
       String transactionId,
-      }) data,
-      ) async {
+    }) data,
+  ) async {
     return lib_epiccash.cancelTransaction(
       data.wallet,
       data.transactionId,
@@ -357,8 +358,8 @@ abstract class LibEpiccash {
     return await m.protect(() async {
       try {
         return await compute(_cancelTransactionWrapper, (
-        wallet: wallet,
-        transactionId: transactionId,
+          wallet: wallet,
+          transactionId: transactionId,
         ));
       } catch (e) {
         throw ("Error canceling epic transaction : ${e.toString()}");
@@ -367,10 +368,10 @@ abstract class LibEpiccash {
   }
 
   static Future<int> _chainHeightWrapper(
-      ({
+    ({
       String config,
-      }) data,
-      ) async {
+    }) data,
+  ) async {
     return lib_epiccash.getChainHeight(data.config);
   }
 
@@ -390,12 +391,12 @@ abstract class LibEpiccash {
   /// Private function for address info function
   ///
   static Future<String> _addressInfoWrapper(
-      ({
+    ({
       String wallet,
       int index,
       String epicboxConfig,
-      }) data,
-      ) async {
+    }) data,
+  ) async {
     return lib_epiccash.getAddressInfo(
       data.wallet,
       data.index,
@@ -414,9 +415,9 @@ abstract class LibEpiccash {
     return await m.protect(() async {
       try {
         return await compute(_addressInfoWrapper, (
-        wallet: wallet,
-        index: index,
-        epicboxConfig: epicboxConfig,
+          wallet: wallet,
+          index: index,
+          epicboxConfig: epicboxConfig,
         ));
       } catch (e) {
         throw ("Error getting address info : ${e.toString()}");
@@ -428,12 +429,12 @@ abstract class LibEpiccash {
   /// Private function for getting transaction fees
   ///
   static Future<String> _transactionFeesWrapper(
-      ({
+    ({
       String wallet,
       int amount,
       int minimumConfirmations,
-      }) data,
-      ) async {
+    }) data,
+  ) async {
     return lib_epiccash.getTransactionFees(
       data.wallet,
       data.amount,
@@ -445,7 +446,7 @@ abstract class LibEpiccash {
   /// get transaction fees for Epic
   ///
   static Future<({int fee, bool strategyUseAll, int total})>
-  getTransactionFees({
+      getTransactionFees({
     required String wallet,
     required int amount,
     required int minimumConfirmations,
@@ -454,9 +455,9 @@ abstract class LibEpiccash {
     return await m.protect(() async {
       try {
         String fees = await compute(_transactionFeesWrapper, (
-        wallet: wallet,
-        amount: amount,
-        minimumConfirmations: minimumConfirmations,
+          wallet: wallet,
+          amount: amount,
+          minimumConfirmations: minimumConfirmations,
         ));
 
         if (available == amount) {
@@ -473,15 +474,15 @@ abstract class LibEpiccash {
               }
             }
             int largestSatoshiFee =
-            ((required - available) * Decimal.fromInt(100000000))
-                .toBigInt()
-                .toInt();
+                ((required - available) * Decimal.fromInt(100000000))
+                    .toBigInt()
+                    .toInt();
             var amountSending = amount - largestSatoshiFee;
             //Get fees for this new amount
             fees = await compute(_transactionFeesWrapper, (
-            wallet: wallet,
-            amount: amountSending,
-            minimumConfirmations: minimumConfirmations,
+              wallet: wallet,
+              amount: amountSending,
+              minimumConfirmations: minimumConfirmations,
             ));
           }
         }
@@ -494,13 +495,13 @@ abstract class LibEpiccash {
         var decodedFees = json.decode(fees);
         var feeItem = decodedFees[0];
         ({
-        bool strategyUseAll,
-        int total,
-        int fee,
+          bool strategyUseAll,
+          int total,
+          int fee,
         }) feeRecord = (
-        strategyUseAll: feeItem['selection_strategy_is_use_all'],
-        total: feeItem['total'],
-        fee: feeItem['fee'],
+          strategyUseAll: feeItem['selection_strategy_is_use_all'],
+          total: feeItem['total'],
+          fee: feeItem['fee'],
         );
         return feeRecord;
       } catch (e) {
@@ -513,13 +514,13 @@ abstract class LibEpiccash {
   /// Private function wrapper for recover wallet function
   ///
   static Future<String> _recoverWalletWrapper(
-      ({
+    ({
       String config,
       String password,
       String mnemonic,
       String name,
-      }) data,
-      ) async {
+    }) data,
+  ) async {
     return lib_epiccash.recoverWallet(
       data.config,
       data.password,
@@ -533,15 +534,15 @@ abstract class LibEpiccash {
   ///
   static Future<void> recoverWallet(
       {required String config,
-        required String password,
-        required String mnemonic,
-        required String name}) async {
+      required String password,
+      required String mnemonic,
+      required String name}) async {
     try {
       await compute(_recoverWalletWrapper, (
-      config: config,
-      password: password,
-      mnemonic: mnemonic,
-      name: name,
+        config: config,
+        password: password,
+        mnemonic: mnemonic,
+        name: name,
       ));
     } catch (e) {
       throw (e.toString());
@@ -552,11 +553,11 @@ abstract class LibEpiccash {
   /// Private function wrapper for delete wallet function
   ///
   static Future<String> _deleteWalletWrapper(
-      ({
+    ({
       String wallet,
       String config,
-      }) data,
-      ) async {
+    }) data,
+  ) async {
     return lib_epiccash.deleteWallet(
       data.wallet,
       data.config,
@@ -572,8 +573,8 @@ abstract class LibEpiccash {
   }) async {
     try {
       return await compute(_deleteWalletWrapper, (
-      wallet: wallet,
-      config: config,
+        wallet: wallet,
+        config: config,
       ));
     } catch (e) {
       throw ("Error deleting wallet : ${e.toString()}");
@@ -584,11 +585,11 @@ abstract class LibEpiccash {
   /// Private function wrapper for open wallet function
   ///
   static Future<String> _openWalletWrapper(
-      ({
+    ({
       String config,
       String password,
-      }) data,
-      ) async {
+    }) data,
+  ) async {
     return lib_epiccash.openWallet(
       data.config,
       data.password,
@@ -604,8 +605,8 @@ abstract class LibEpiccash {
   }) async {
     try {
       return await compute(_openWalletWrapper, (
-      config: config,
-      password: password,
+        config: config,
+        password: password,
       ));
     } catch (e) {
       throw ("Error opening wallet : ${e.toString()}");
@@ -616,15 +617,15 @@ abstract class LibEpiccash {
   /// Private function for txHttpSend function
   ///
   static Future<String> _txHttpSendWrapper(
-      ({
+    ({
       String wallet,
       int selectionStrategyIsAll,
       int minimumConfirmations,
       String message,
       int amount,
       String address,
-      }) data,
-      ) async {
+    }) data,
+  ) async {
     return lib_epiccash.txHttpSend(
       data.wallet,
       data.selectionStrategyIsAll,
@@ -648,12 +649,12 @@ abstract class LibEpiccash {
   }) async {
     try {
       var result = await compute(_txHttpSendWrapper, (
-      wallet: wallet,
-      selectionStrategyIsAll: selectionStrategyIsAll,
-      minimumConfirmations: minimumConfirmations,
-      message: message,
-      amount: amount,
-      address: address,
+        wallet: wallet,
+        selectionStrategyIsAll: selectionStrategyIsAll,
+        minimumConfirmations: minimumConfirmations,
+        message: message,
+        amount: amount,
+        address: address,
       ));
       if (result.toUpperCase().contains("ERROR")) {
         throw Exception("Error creating transaction ${result.toString()}");
@@ -666,8 +667,8 @@ abstract class LibEpiccash {
       final part2 = jsonDecode(slate[1] as String);
 
       ({String slateId, String commitId}) data = (
-      slateId: part1[0]['tx_slate_id'],
-      commitId: part2['tx']['body']['outputs'][0]['commit'],
+        slateId: part1[0]['tx_slate_id'],
+        commitId: part2['tx']['body']['outputs'][0]['commit'],
       );
 
       return data;
@@ -681,8 +682,9 @@ abstract class LibEpiccash {
     required String epicboxConfig,
   }) {
     try {
-      ListenerManager.pointer = lib_epiccash.epicboxListenerStart(wallet, epicboxConfig);
-    } catch(e) {
+      ListenerManager.pointer =
+          lib_epiccash.epicboxListenerStart(wallet, epicboxConfig);
+    } catch (e) {
       throw ("Error starting wallet listener ${e.toString()}");
     }
   }

--- a/lib/lib.dart
+++ b/lib/lib.dart
@@ -188,24 +188,32 @@ abstract class LibEpiccash {
     required int startHeight,
     required int numberOfBlocks,
   }) async {
-    return int.parse(await m.protect(() async {
-      try {
-        return await compute(_scanOutputsWrapper, (
-        wallet: wallet,
-        startHeight: startHeight,
-        numberOfBlocks: numberOfBlocks,
-        ));
-      } catch (e) {
-        throw ("Error getting scanning outputs : ${e.toString()}");
+    try {
+      final result = await m.protect(() async {
+        return await compute(
+          _scanOutputsWrapper,
+          (
+            wallet: wallet,
+            startHeight: startHeight,
+            numberOfBlocks: numberOfBlocks,
+          ),
+        );
+      });
+      final response = int.tryParse(result);
+      if (response == null) {
+        throw Exception(result);
       }
-    }));
+      return response;
+    } catch (e) {
+      throw ("LibEpiccash.scanOutputs failed: ${e.toString()}");
+    }
   }
 
   ///
   /// Private function wrapper for create transactions
   ///
   static Future<String> _createTransactionWrapper(
-      ({
+    ({
       String wallet,
       int amount,
       String address,


### PR DESCRIPTION
Thanks for the error handling code sample, Julian!

The following additional functions have poor error-handing and could benefit from similar changes:
 - [x] `scanOutputs`
 - [ ] **`cancelTransaction`**
 - [ ] **`recoverWallet`**
 - [ ] `initializeNewWallet`
 - [ ] `createTransaction`
 - [ ] `getChainHeight`
 - [ ] `getAddressInfo`
 - [ ] `deleteWallet`
 - [ ] `openWallet`
 - [ ] `txHttpSend`

Fair but could be good:
 - [ ] **`getTransactions`**
 - [ ] `validateSendAddress`
 
Good but could be better:
 - [ ] **`getWalletBalances`**
 - [ ] `getMnemonic`
 
 Lots of `catch`es could use additional error context: where we return the original/passed error, add extra contextual information.