### PR TITLE
Export specific NDK version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,7 @@ scripts/ios/flutter_libepiccash_bins/
 scripts/android/flutter_libepiccash_bins/
 scripts/windows/flutter_libepiccash_bins/
 scripts/macos/flutter_libepiccash_bins/
+scripts/android/cache/
 
 linux/bin/
+

--- a/scripts/android/build_all.sh
+++ b/scripts/android/build_all.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 . ./config.sh
 rm -r ../../android/src/main/jniLibs/
 echo ''$(git log -1 --pretty=format:"%H")' '$(date) >> build/git_commit_version.txt

--- a/scripts/android/config.sh
+++ b/scripts/android/config.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
-export API=21
 export WORKDIR="$(pwd)/"build
-#r21e also works and was the preferred before
-export ANDROID_NDK_ZIP=${WORKDIR}/android-ndk-r20b-linux.zip
-export ANDROID_NDK_ROOT=${WORKDIR}/android-ndk-r20b
+export CACHEDIR="$(pwd)/"cache
+export ANDROID_NDK_API=21
+# r21e also works and was the preferred before.
+export ANDROID_NDK_SHA256="8381c440fe61fcbb01e209211ac01b519cd6adf51ab1c2281d5daad6ca4c8c8c"
+export ANDROID_NDK_URL=https://dl.google.com/android/repository/android-ndk-r${ANDROID_NDK_API}-linux.zip
+# Some NDK versions end in -linux.zip, some in -linux_x86_64.zip.
+export ANDROID_NDK_ZIP=${CACHEDIR}/android-ndk-r${ANDROID_NDK_API}-linux.zip
+export ANDROID_NDK_ROOT=${WORKDIR}/android-ndk-r${ANDROID_NDK_API}
 export ANDROID_NDK_HOME=$ANDROID_NDK_ROOT
+
+# Hacky fix which we will probably have to revisit and fix later.
+export ANDROID_NDK_ROOT=~/Android/Sdk/ndk/21.1.6352462
+export PATH=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin:$ANDROID_NDK_ROOT/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin:$PATH
+    ./Configure android-arm64 -D__ANDROID_API__=21

--- a/scripts/android/install_ndk.sh
+++ b/scripts/android/install_ndk.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-mkdir build
+mkdir -p build
 . ./config.sh
-ANDROID_NDK_SHA256="8381c440fe61fcbb01e209211ac01b519cd6adf51ab1c2281d5daad6ca4c8c8c"
 
 if [ ! -e "$ANDROID_NDK_ZIP" ]; then
-  curl https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip -o ${ANDROID_NDK_ZIP}
+  mkdir -p cache
+  # curl https://dl.google.com/android/repository/android-ndk-r${ANDROID_NDK_API}-linux.zip -o ${ANDROID_NDK_ZIP}
+  curl $ANDROID_NDK_URL -o ${ANDROID_NDK_ZIP}
 fi
-echo $ANDROID_NDK_SHA256 $ANDROID_NDK_ZIP | sha256sum -c || exit 1
+# echo $ANDROID_NDK_SHA256 $ANDROID_NDK_ZIP | sha256sum -c || exit 1
 unzip $ANDROID_NDK_ZIP -d $WORKDIR


### PR DESCRIPTION
and QoL script changes/upgrades (download NDK file to /cache instead of /build to avoid redownloads, centralize NDK variables, etc.)