### PR TITLE
fix(macos/ios): use shasum -a 256 -c instead of sha256sum -c

### DIFF
--- a/scripts/ios/download.sh
+++ b/scripts/ios/download.sh
@@ -21,7 +21,7 @@ curl -fSL "${BASE_URL}/${TAG}/checksums.txt" -o "$TMPDIR/checksums.txt"
 download_and_verify() {
     local asset="$1"
     curl -fSL "${BASE_URL}/${TAG}/${asset}" -o "$TMPDIR/${asset}"
-    grep "^[0-9a-f]*  ${asset}$" "$TMPDIR/checksums.txt" | (cd "$TMPDIR" && sha256sum -c)
+    grep "^[0-9a-f]*  ${asset}$" "$TMPDIR/checksums.txt" | (cd "$TMPDIR" && shasum -a 256 -c)
 }
 
 download_and_verify "libepic_cash_wallet-ios-aarch64.a"

--- a/scripts/macos/download.sh
+++ b/scripts/macos/download.sh
@@ -20,7 +20,7 @@ curl -fSL "${BASE_URL}/${TAG}/checksums.txt" -o "$TMPDIR/checksums.txt"
 download_and_verify() {
     local asset="$1"
     curl -fSL "${BASE_URL}/${TAG}/${asset}" -o "$TMPDIR/${asset}"
-    grep "^[0-9a-f]*  ${asset}$" "$TMPDIR/checksums.txt" | (cd "$TMPDIR" && sha256sum -c)
+    grep "^[0-9a-f]*  ${asset}$" "$TMPDIR/checksums.txt" | (cd "$TMPDIR" && shasum -a 256 -c)
 }
 
 download_and_verify "EpicWallet.xcframework.zip"


### PR DESCRIPTION
 macOS runners ship a sha256sum binary that does not accept -c, breaking the download verification step. 
shasum -a 256 -c works on both macOS   and Linux.
  
